### PR TITLE
fix missing return value

### DIFF
--- a/src/RE/GFxResourceKey.cpp
+++ b/src/RE/GFxResourceKey.cpp
@@ -37,6 +37,7 @@ namespace RE
 	{
 		_keyInterface = a_rhs._keyInterface;
 		_keyData = a_rhs._keyData;
+		return *this;
 	}
 
 


### PR DESCRIPTION
Just a tiny fix for a missing return value that kept CommonLib from compiling.
Just because Github preview cuts off the function declaration, its `GFxResourceKey& GFxResourceKey::operator=(const GFxResourceKey& a_rhs)`