### PR TITLE
Fixed wrong type

### DIFF
--- a/include/RE/FavoritesMenu.h
+++ b/include/RE/FavoritesMenu.h
@@ -44,7 +44,7 @@ namespace RE
 
 		// members
 		GFxValue			root;				// 40 - "Menu_mc"
-		BSTArray<Entry*>	favorites;			// 58
+		BSTArray<Entry>		favorites;			// 58
 		UInt16				unk70;				// 70
 		bool				pcControlsReady;	// 72
 		bool				isVampire;			// 73


### PR DESCRIPTION
Fixed the type of the array in the favorites menu, as it contains entries and not pointers to them.