### PR TITLE
IMessageBoxCallback Fix

### DIFF
--- a/include/RE/Menus/IMessageBoxCallback/IMessageBoxCallback.h
+++ b/include/RE/Menus/IMessageBoxCallback/IMessageBoxCallback.h
@@ -19,7 +19,7 @@ namespace RE
 		};
 
 
-		virtual ~IMessageBoxCallback();	 // 00
+		virtual ~IMessageBoxCallback() = default;	 // 00
 
 		// add
 		virtual void Run(Message a_msg) = 0;  // 01


### PR DESCRIPTION
Added default destructor so I can inherit from IMessageBoxCallback. Currently there is no implementation and the linker fails