### PR TITLE
corrected form type check in GetActorOwner()

### DIFF
--- a/include/RE/T/TESObjectREFR.cpp
+++ b/include/RE/T/TESObjectREFR.cpp
@@ -75,7 +75,7 @@ namespace RE
 	TESNPC* TESObjectREFR::GetActorOwner()
 	{
 		auto xOwnership = extraList.GetByType<ExtraOwnership>();
-		if (xOwnership && xOwnership->owner && xOwnership->owner->Is(FormType::ActorCharacter)) {
+		if (xOwnership && xOwnership->owner && xOwnership->owner->Is(FormType::NPC)) {
 			return static_cast<TESNPC*>(xOwnership->owner);
 		} else {
 			return nullptr;


### PR DESCRIPTION
A minor correction. Just to make sure, I checked all live references in a new game and found that they only have one of two form types as an owner: TESNPC or TESFaction, never Actor.