### PR TITLE
implict enum to integer warning fix

### DIFF
--- a/include/RE/A/ActorState.h
+++ b/include/RE/A/ActorState.h
@@ -69,7 +69,7 @@ namespace RE
 		kWaitingForSitAnim = 2,
 
 		kIsSitting = 3,
-		kRidingMount = kIsSitting,
+		kRidingMount = static_cast<int>(kIsSitting),
 
 		kWantToStand = 4,
 

--- a/include/RE/A/ActorState.h
+++ b/include/RE/A/ActorState.h
@@ -69,7 +69,7 @@ namespace RE
 		kWaitingForSitAnim = 2,
 
 		kIsSitting = 3,
-		kRidingMount = static_cast<int>(kIsSitting),
+		kRidingMount = static_cast<std::underlying_type_t<SIT_SLEEP_STATE>>(kIsSitting),
 
 		kWantToStand = 4,
 


### PR DESCRIPTION
explictly cast the enum to an integer to handle compiler warnings