### PR TITLE
Update MenuTopicManager.h

### DIFF
--- a/include/RE/M/MenuTopicManager.h
+++ b/include/RE/M/MenuTopicManager.h
@@ -81,7 +81,7 @@ namespace RE
 		bool                         unkB4;                 // B4
 		bool                         unkB5;                 // B5
 		bool                         unkB6;                 // B6
-		bool                         unkB7;                 // B7
+		bool                         dialogueListHasChild;  // B7
 		bool                         unkB8;                 // B8
 		bool                         unkB9;                 // B9
 		bool                         unkBA;                 // BA


### PR DESCRIPTION
I believe `unkB7` could be renamed to `dialogueListHasChild` due to its usage in the function seen here

```
char *__fastcall MenuTopicManager::PossiblySetTopic_14056E5F0(MenuTopicManager *MenuTopicManagerPtr, int32 DialogListIndexWhichStartsAtZero)
{
  char *result; // rax
  BSSimpleList_DialogueItem2__ *DialogListEntry; // rdi
  int64 v5; // rbx
  int64 v6; // rax
  void *v7; // rax
  int64 a2a; // [rsp+50h] [rbp+8h] BYREF

  result = 0i64;
  DialogListEntry = MenuTopicManagerPtr->dialogueList;
  if ( MenuTopicManagerPtr->unkB7 )
    DialogListEntry = DialogListEntry->Next_8;
  if ( !DialogListEntry )
    goto LABEL_18;
  while ( result < DialogListIndexWhichStartsAtZero )
  {
    DialogListEntry = DialogListEntry->Next_8;
    result = (result + 1);                      // result++;
    if ( !DialogListEntry )
      goto LABEL_18;
  }
  MenuTopicManagerPtr->selectedResponseNode = DialogListEntry;
  a2a = 0i64;
  LookupREFRByHandle3_1401328A0(&MenuTopicManagerPtr->speaker, &a2a);
  v5 = a2a;
  if ( a2a )
  {
    v6 = 0i64;
    if ( *(a2a + 26) == 62 )
      v6 = a2a;
    if ( !v6 && DialogListEntry->Item_0 )
    {
      Character::sub_1402A6E50(a2a, DialogListEntry->Item_0->unk50);
      v7 = TESTopic::sub_14038F9A0(DialogListEntry->Item_0->unk50, v5, assaulter, 0i64, 0i64, 0i64);
      TESObjectREFR::sub_1402A6E20(v5, v7);
    }
  }
  if ( v5 )
  {
    if ( (_InterlockedDecrement((v5 + 40)) & 0x3FF) == 0 )
      (*(*(v5 + 32) + 8i64))(v5 + 32);
  }
  result = MenuTopicManagerPtr->selectedResponseNode;
  if ( *result )
    LOBYTE(result) = 1;
  else
LABEL_18:
    LOBYTE(result) = 0;
  return result;
}
```