### PR TITLE
Update BSTArray.h

### DIFF
--- a/include/RE/B/BSTArray.h
+++ b/include/RE/B/BSTArray.h
@@ -33,8 +33,8 @@ namespace RE
 
 		inline ~BSTArrayBase() noexcept { _size = 0; }
 
-		constexpr BSTArrayBase& operator=(const BSTArrayBase&) noexcept = default;
-		constexpr BSTArrayBase& operator=(BSTArrayBase&&) noexcept = default;
+		BSTArrayBase& operator=(const BSTArrayBase&) noexcept = default;
+		BSTArrayBase& operator=(BSTArrayBase&&) noexcept = default;
 
 		[[nodiscard]] constexpr bool      empty() const noexcept { return _size == 0; }
 		[[nodiscard]] constexpr size_type size() const noexcept { return _size; }


### PR DESCRIPTION
BSTArray.h(36,3): error: defaulted definition of copy assignment operator is not constexpr
                constexpr BSTArrayBase& operator=(const BSTArrayBase&) noexcept = default;

BSTArray.h(37,3): error: defaulted definition of move assignment operator is not constexpr
                constexpr BSTArrayBase& operator=(BSTArrayBase&&) noexcept = default;

A clang fix