### PR TITLE
Papyrus fixes

### DIFF
--- a/include/RE/P/PackUnpack.h
+++ b/include/RE/P/PackUnpack.h
@@ -66,7 +66,7 @@ namespace RE
 		[[nodiscard]] inline TypeInfo::RawType GetRawType()
 		{
 			using value_type = typename T::value_type;
-			if constexpr (is_builtin_v<value_type>) {
+			if constexpr (is_builtin_convertible_v<value_type>) {
 				return *(stl::enumeration{ vm_type_v<T> } + TypeInfo::RawType::kNoneArray);
 			} else if constexpr (is_form_pointer_v<value_type>) {
 				return *(stl::enumeration{ GetRawTypeFromVMType(static_cast<VMTypeID>(unwrapped_type_t<T>::FORMTYPE)) } + TypeInfo::RawType::kObject);

--- a/include/RE/P/PackUnpackImpl.h
+++ b/include/RE/P/PackUnpackImpl.h
@@ -75,7 +75,11 @@ namespace RE
 			assert(a_src);
 
 			std::remove_const_t<T> container;
-			auto                   array = a_src->GetArray();
+			if (a_src->IsNoneObject()) {
+				return container;
+			}
+
+			auto array = a_src->GetArray();
 			if (!array) {
 				assert(false);
 				return container;


### PR DESCRIPTION
A couple of issues I ran into while working with Papyrus.

1. Arrays of built-in convertible types like `std::vector<std::string>` should be allowed.
2. Passing a `None` value to an array causes an assertion failure inside of `GetArray`, so it needs to be checked for separately with `IsNoneObject`.