### PR TITLE
Pattern matching function

### DIFF
--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -191,6 +191,80 @@ namespace REL
 
 			return func(std::forward<First>(a_first), std::addressof(result), std::forward<Rest>(a_rest)...);
 		}
+
+		struct optional_byte
+		{
+			constexpr optional_byte() {}
+			constexpr optional_byte(std::nullopt_t) {}
+			constexpr optional_byte(std::uint8_t a_value) :
+				has_value(true), value(a_value) {}
+
+			optional_byte& operator=(std::nullopt_t)
+			{
+				has_value = false;
+				return *this;
+			}
+
+			optional_byte& operator=(std::uint8_t a_value)
+			{
+				has_value = true;
+				value = a_value;
+				return *this;
+			}
+
+			bool         has_value = false;
+			std::uint8_t value = 0;
+		};
+
+		template <std::size_t N>
+		struct pattern_impl
+		{
+			static constexpr auto Size = N / 3;
+
+			constexpr pattern_impl(const char (&a_str)[N])
+			{
+				for (std::size_t i = 0; i < Size; i++) {
+					data[i] = parse_byte(a_str[i * 3], a_str[i * 3 + 1]);
+				}
+			}
+
+			[[nodiscard]] bool match(const void* a_address) const
+			{
+				for (std::size_t i = 0; i < Size; i++) {
+					if (!data[i].has_value) {
+						continue;
+					}
+
+					if (data[i].value != static_cast<const std::uint8_t*>(a_address)[i]) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+
+			[[nodiscard]] static constexpr optional_byte parse_byte(char a_char1, char a_char2)
+			{
+				if (a_char1 == '?' && a_char2 == '?') {
+					return std::nullopt;
+				}
+
+				return parse_hex(a_char1) * 0x10 + parse_hex(a_char2);
+			}
+
+			[[nodiscard]] static constexpr std::uint8_t parse_hex(char a_char)
+			{
+				if (a_char >= '0' && a_char <= '9') {
+					return a_char - '0';
+				} else if (a_char >= 'A' && a_char <= 'F') {
+					return a_char + 0xA - 'A';
+				} else if (a_char >= 'a' && a_char <= 'f') {
+					return a_char + 0xA - 'a';
+				}
+			}
+
+			optional_byte data[Size];
+		};
 	}
 
 	inline constexpr std::uint8_t NOP = 0x90;
@@ -962,6 +1036,20 @@ namespace REL
 		// clang-format on
 
 		std::uintptr_t _impl{ 0 };
+	};
+
+	template <detail::pattern_impl Impl>
+	struct Pattern
+	{
+		[[nodiscard]] bool match(const void* a_address) const
+		{
+			return Impl.match(a_address);
+		}
+
+		[[nodiscard]] bool match(std::uintptr_t a_address) const
+		{
+			return Impl.match(reinterpret_cast<const void*>(a_address));
+		}
 	};
 }
 

--- a/include/REL/Relocation.h
+++ b/include/REL/Relocation.h
@@ -217,7 +217,7 @@ namespace REL
 		};
 
 		template <std::size_t N>
-		struct pattern_impl
+		requires(N % 3 == 0) struct pattern_impl
 		{
 			static constexpr auto Size = N / 3;
 


### PR DESCRIPTION
This is a helper for plugins to verify bytes before writing patches, either in case of an incompatibility between plugins, or unexpected changes from game updates.

It's passed in as a template argument to ensure compile-time evaluation. If the string isn't valid, intellisense will raise an error.

Example usage:
```c++
auto& trampoline = SKSE::GetTrampoline();

REL::Relocation<std::uintptr_t> hook{ 51610, 0xFE };

constexpr auto relcall = REL::Pattern<"E8 ?? ?? ?? ??">{};

if (relcall.match(hook.address())) {
    _LoadMovie = trampoline.write_call<5>(hook.address(), LoadMovie);
}
else {
    logger::warn("Failed to install patch"sv);
}
```