### PR TITLE
Update plugin version info struct for SKSE 2.2.0 / AE 1.6.629

### DIFF
--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -412,11 +412,11 @@ namespace SKSE
 	static_assert(offsetof(PluginVersionData, pluginName) == 0x008);
 	static_assert(offsetof(PluginVersionData, author) == 0x108);
 	static_assert(offsetof(PluginVersionData, supportEmail) == 0x208);
-	static_assert(offsetof(PluginVersionData, padding2) == 0x309);
-	static_assert(offsetof(PluginVersionData, padding3) == 0x30A);
-	static_assert(offsetof(PluginVersionData, padding5) == 0x30D);
-	static_assert(offsetof(PluginVersionData, padding6) == 0x30E);
-	static_assert(offsetof(PluginVersionData, compatibleVersions) == 0x310);
-	static_assert(offsetof(PluginVersionData, xseMinimum) == 0x350);
+	static_assert(offsetof(PluginVersionData, padding2) == 0x305);
+	static_assert(offsetof(PluginVersionData, padding3) == 0x306);
+	static_assert(offsetof(PluginVersionData, padding5) == 0x309);
+	static_assert(offsetof(PluginVersionData, padding6) == 0x30A);
+	static_assert(offsetof(PluginVersionData, compatibleVersions) == 0x30C);
+	static_assert(offsetof(PluginVersionData, xseMinimum) == 0x34C);
 	static_assert(sizeof(PluginVersionData) == 0x350);
 }

--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -383,7 +383,7 @@ namespace SKSE
 		std::uint32_t       pluginVersion = 0;
 		char                pluginName[256] = {};
 		char                author[256] = {};
-		char                supportEmail[256] = {};
+		char                supportEmail[252] = {};
 		bool                noStructUse: 1 = false;
 		std::uint8_t        padding1: 7 = 0;
 		std::uint8_t        padding2 = 0;

--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -374,19 +374,26 @@ namespace SKSE
 		constexpr void MinimumRequiredXSEVersion(REL::Version a_version) noexcept { xseMinimum = a_version.pack(); }
 		constexpr void PluginName(std::string_view a_plugin) noexcept { SetCharBuffer(a_plugin, std::span{ pluginName }); }
 		constexpr void PluginVersion(REL::Version a_version) noexcept { pluginVersion = a_version.pack(); }
+		constexpr void HasNoStructUse(bool a_value) noexcept { noStructUse = a_value; }
 		constexpr void UsesAddressLibrary(bool a_value) noexcept { addressLibrary = a_value; }
 		constexpr void UsesSigScanning(bool a_value) noexcept { sigScanning = a_value; }
+		constexpr void UsesStructsPost629(bool a_value) noexcept { structsPost629 = a_value; }
 
 		const std::uint32_t dataVersion{ kVersion };
 		std::uint32_t       pluginVersion = 0;
 		char                pluginName[256] = {};
 		char                author[256] = {};
 		char                supportEmail[256] = {};
-		bool                addressLibrary: 1 = false;
-		bool                sigScanning: 1 = false;
-		std::uint8_t        padding1: 6 = 0;
+		bool                noStructUse: 1 = false;
+		std::uint8_t        padding1: 7 = 0;
 		std::uint8_t        padding2 = 0;
 		std::uint16_t       padding3 = 0;
+		bool                addressLibrary: 1 = false;
+		bool                sigScanning: 1 = false;
+		bool                structsPost629: 1 = true;
+		std::uint8_t        padding4: 5 = 0;
+		std::uint8_t        padding5 = 0;
+		std::uint16_t       padding6 = 0;
 		std::uint32_t       compatibleVersions[16] = {};
 		std::uint32_t       xseMinimum = 0;
 
@@ -407,7 +414,9 @@ namespace SKSE
 	static_assert(offsetof(PluginVersionData, supportEmail) == 0x208);
 	static_assert(offsetof(PluginVersionData, padding2) == 0x309);
 	static_assert(offsetof(PluginVersionData, padding3) == 0x30A);
-	static_assert(offsetof(PluginVersionData, compatibleVersions) == 0x30C);
-	static_assert(offsetof(PluginVersionData, xseMinimum) == 0x34C);
-	static_assert(sizeof(PluginVersionData) == 0x350);
+	static_assert(offsetof(PluginVersionData, padding5) == 0x30D);
+	static_assert(offsetof(PluginVersionData, padding6) == 0x30E);
+	static_assert(offsetof(PluginVersionData, compatibleVersions) == 0x310);
+	static_assert(offsetof(PluginVersionData, xseMinimum) == 0x350);
+	static_assert(sizeof(PluginVersionData) == 0x354);
 }

--- a/include/SKSE/Interfaces.h
+++ b/include/SKSE/Interfaces.h
@@ -418,5 +418,5 @@ namespace SKSE
 	static_assert(offsetof(PluginVersionData, padding6) == 0x30E);
 	static_assert(offsetof(PluginVersionData, compatibleVersions) == 0x310);
 	static_assert(offsetof(PluginVersionData, xseMinimum) == 0x350);
-	static_assert(sizeof(PluginVersionData) == 0x354);
+	static_assert(sizeof(PluginVersionData) == 0x350);
 }


### PR DESCRIPTION
SKSE 2.2.0 changes the plugin API's `SKSEPluginVersionData` struct to allow plugins to indicate compatibility with AE post-1.6.629 as a bit in the `versionIndependence` bitfield. It also adds a new `versionIndependenceEx` bitfield with a bit to further indicate that the plugin is compatible across both sides of structure changes in 1.6.629.

This PR updates CommonLibSSE to account for and expose these changes.