### PR TITLE
Get log directory from game exe

### DIFF
--- a/src/SKSE/Logger.cpp
+++ b/src/SKSE/Logger.cpp
@@ -103,7 +103,9 @@ namespace SKSE
 			}
 
 			std::filesystem::path path = knownPath.get();
-			path /= "My Games/Skyrim Special Edition/SKSE"sv;
+			path /= "My Games"sv;
+			path /= *REL::Relocation<const char**>(REL::ID(380738)).get();
+			path /= "SKSE"sv;
 			return path;
 		}
 	}


### PR DESCRIPTION
The GOG version uses a different log directory from the Steam version. This should make it choose the correct one for both.