### PR TITLE
fix: logger namespace mismatching

### DIFF
--- a/src/SKSE/Logger.cpp
+++ b/src/SKSE/Logger.cpp
@@ -59,37 +59,6 @@ namespace SKSE
 		};
 	}
 
-	void add_papyrus_sink(std::regex a_filter)
-	{
-		auto handler = Impl::LogEventHandler::GetSingleton();
-		handler->SetFilter(std::move(a_filter));
-
-		SKSE::RegisterForAPIInitEvent([]() {
-			auto papyrus = SKSE::GetPapyrusInterface();
-			if (papyrus) {
-				papyrus->Register([](RE::BSScript::IVirtualMachine* a_vm) {
-					auto handler = Impl::LogEventHandler::GetSingleton();
-					a_vm->RegisterForLogEvent(handler);
-					return true;
-				});
-			}
-		});
-	}
-
-	void remove_papyrus_sink()
-	{
-		SKSE::RegisterForAPIInitEvent([]() {
-			auto papyrus = SKSE::GetPapyrusInterface();
-			if (papyrus) {
-				papyrus->Register([](RE::BSScript::IVirtualMachine* a_vm) {
-					auto handler = Impl::LogEventHandler::GetSingleton();
-					a_vm->UnregisterForLogEvent(handler);
-					return true;
-				});
-			}
-		});
-	}
-
 	namespace log
 	{
 		std::optional<std::filesystem::path> log_directory()
@@ -107,6 +76,37 @@ namespace SKSE
 			path /= *REL::Relocation<const char**>(REL::ID(380738)).get();
 			path /= "SKSE"sv;
 			return path;
+		}
+
+		void add_papyrus_sink(std::regex a_filter)
+		{
+			auto handler = Impl::LogEventHandler::GetSingleton();
+			handler->SetFilter(std::move(a_filter));
+
+			SKSE::RegisterForAPIInitEvent([]() {
+				auto papyrus = SKSE::GetPapyrusInterface();
+				if (papyrus) {
+					papyrus->Register([](RE::BSScript::IVirtualMachine* a_vm) {
+						auto handler = Impl::LogEventHandler::GetSingleton();
+						a_vm->RegisterForLogEvent(handler);
+						return true;
+					});
+				}
+			});
+		}
+
+		void remove_papyrus_sink()
+		{
+			SKSE::RegisterForAPIInitEvent([]() {
+				auto papyrus = SKSE::GetPapyrusInterface();
+				if (papyrus) {
+					papyrus->Register([](RE::BSScript::IVirtualMachine* a_vm) {
+						auto handler = Impl::LogEventHandler::GetSingleton();
+						a_vm->UnregisterForLogEvent(handler);
+						return true;
+					});
+				}
+			});
 		}
 	}
 }


### PR DESCRIPTION
In Logger.h "add_papyrus_sink" and "remove_papyrus_sink" functions in the SKSE::log namespace
An "unresolved external symbol" error occurs during compilation if you try to call one of these functions.